### PR TITLE
Responsiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
+    "classnames": "^2.5.1",
     "install": "^0.13.0",
     "next": "14.2.3",
     "react": "^18",

--- a/src/components/ImageGroup.tsx
+++ b/src/components/ImageGroup.tsx
@@ -9,7 +9,7 @@ interface ImageGroupProps {
 
 export default function ImageGroup({ images }: ImageGroupProps) {
   return (
-    <div className="flex w-full h-full gap-10 overflow-x-scroll">
+    <div className="flex w-full h-full gap-10 overflow-x-scroll no-scrollbar">
       {images.map((image, index) => (
         <Image
           key={index}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,10 +46,10 @@ const Home = ({ data }: InferGetStaticPropsType<typeof getStaticProps>) => {
             }];
             
   return (
-    <main className="flex min-h-screen gap-16 flex-col p-24 container">
+    <main style={{backgroundColor: 'blue'}} className="flex min-h-screen gap-16 flex-col container">
       <div>
-        <h1 className="max-w-md mb-5">{heading ?? fallbackHeading}</h1>
-        <p className="max-w-xl">{subheading ?? fallbackSubheading}</p>
+        <h1>{heading ?? fallbackHeading}</h1>
+        <p>{subheading ?? fallbackSubheading}</p>
       </div>
       <section className=".cta">
           <Button url={ctaButtonUrl ?? fallbackCtaButtonUrl}>
@@ -57,14 +57,14 @@ const Home = ({ data }: InferGetStaticPropsType<typeof getStaticProps>) => {
           </Button> 
       </section>
       <div className="flex flex-col gap-y-4">
-        <div className="max-w-xl">
+        <div>
           <h1 className="mb-5">
             <span>{bodyHeading ?? fallbackBodyHeading}</span>
             <span className="text-green-500">{bodySubheading ?? fallbackBodySubheading}</span>
           </h1>
           <p>{bodyText ?? fallbackBodyText}</p>
         </div>
-        <ol className="list-decimal mb-10 max-w-xl">
+        <ol className="list-decimal mb-10">
           {bodyList ? bodyList.map((listItem: { children: Array<{ type: string; text: string; }>}, index: number) => {
             const text = listItem?.children[0]?.text;
             return (<li key={index}>{text}</li>);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,7 +46,7 @@ const Home = ({ data }: InferGetStaticPropsType<typeof getStaticProps>) => {
             }];
             
   return (
-    <main style={{backgroundColor: 'blue'}} className="flex min-h-screen gap-16 flex-col container">
+    <main className="flex min-h-screen gap-16 flex-col container">
       <div>
         <h1>{heading ?? fallbackHeading}</h1>
         <p>{subheading ?? fallbackSubheading}</p>

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -1,5 +1,7 @@
 import { Source_Serif_4 } from "next/font/google";
 
+import classNames from 'classnames';
+
 const sourceSerif = Source_Serif_4({
   subsets: ["latin"],
   weight: ["400", "700"],
@@ -8,7 +10,11 @@ const sourceSerif = Source_Serif_4({
 const RootLayout = ({ children }: Readonly<{children: React.ReactNode; }>) => {
   return (
     <>
-      <div style={{ backgroundColor: 'red' }} className={sourceSerif.className}>{children}</div>
+      <div className={
+        classNames('mx-auto-px-3 py-6', sourceSerif.className)}
+      >
+        {children}
+      </div>
     </>
   )
 }

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -11,7 +11,7 @@ const RootLayout = ({ children }: Readonly<{children: React.ReactNode; }>) => {
   return (
     <>
       <div className={
-        classNames('mx-auto-px-3 py-6', sourceSerif.className)}
+        classNames(`mx-auto-px-3 py-6 md:px-6 md:py-10 lg:px-4 xl:py-10`, sourceSerif.className)}
       >
         {children}
       </div>

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -8,7 +8,7 @@ const sourceSerif = Source_Serif_4({
 const RootLayout = ({ children }: Readonly<{children: React.ReactNode; }>) => {
   return (
     <>
-      <div className={sourceSerif.className}>{children}</div>
+      <div style={{ backgroundColor: 'red' }} className={sourceSerif.className}>{children}</div>
     </>
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -15,7 +15,6 @@
     }
 }
 
-
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+    /*Hide scrollbar for Chrome, Safari, and Opera */
+    .no-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge, and Firefox */
+    .no-scrollbar {
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+    }
+}
+
+
 @layer base {
   :root {
     --background: 0 0% 100%;


### PR DESCRIPTION
- Remove horizontal scrollbar from ImageGroup and homepage
- Remove css related stylings for width and height from child components and move to layout components
- Make layout component responsive for each device dimension in Chrome (Arc)