### PR TITLE
feat: header

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,16 +1,18 @@
 export default function Footer() {
   return (
-    <div className="mt-10 py-10 border-t">
-      <div className="flex gap-6 mb-8">
-        <a href="https://discord.gg/fcpeKMKn3E" target="_blank">
-          Discord
-        </a>
-        <a href="https://buildspace.com/#tnkr.ai" target="_blank">
-          Buildspace
-        </a>
-      </div>
+    <footer className="container">
+      <div className="mt-10 py-10 border-t">
+        <div className="flex gap-6 mb-8">
+          <a href="https://discord.gg/fcpeKMKn3E" target="_blank">
+            Discord
+          </a>
+          <a href="https://buildspace.com/#tnkr.ai" target="_blank">
+            Buildspace
+          </a>
+        </div>
 
-      <p>© {new Date().getFullYear()}, All rights reserved</p>
-    </div>
+        <p>© {new Date().getFullYear()}, All rights reserved</p>
+      </div>
+    </footer>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 export default function Footer() {
   return (
     <div className="mt-10 py-10 border-t">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import Button from "./ui/Button";
 
 export default function Header() {
   return (
-    <header className="flex justify-between items-center w-full py-4 mb-16 border-b">
+    <header className="fixed w-full flex justify-between items-center py-2.5 border-b bg-black container">
       <Link href="/">tnkr.ai</Link>
 
       <Button asChild size="sm" variant="outline">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import Button from "./ui/Button";
+
+export default function Header() {
+  return (
+    <header className="flex justify-between items-center w-full py-4 mb-16 border-b">
+      <Link href="/">tnkr.ai</Link>
+
+      <Button asChild size="sm" variant="outline">
+        <a href="https://discord.gg/fcpeKMKn3E" target="_blank">
+          Join Our Discord
+        </a>
+      </Button>
+    </header>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,65 +1,58 @@
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@lib/utils";
+import { Slot, Slottable } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 import React from "react";
 
-import { useRouter } from "next/router";
-
 const buttonVariants = cva(
-    "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-sans font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
-    {
-        variants: {
-            variant: {
-                default:
-                    "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-                destructive:
-                    "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-                outline:
-                    "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-                secondary:
-                    "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-                ghost: "hover:bg-accent hover:text-accent-foreground",
-                link: "text-primary underline-offset-4 hover:underline",
-            },
-            size: {
-                default: "h-9 px-4 py-2",
-                sm: "h-8 rounded-full px-3 text-xs",
-                lg: "h-10 rounded-full px-8",
-                icon: "h-9 w-9",
-            },
-        },
-        defaultVariants: {
-            variant: "default",
-            size: "default",
-        },
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-sans font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-full px-3 text-xs",
+        lg: "h-10 rounded-full px-8",
+        icon: "h-9 w-9",
+      },
     },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
 );
 
 export interface ButtonProps
-    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-        VariantProps<typeof buttonVariants> {
-    asChild?: boolean;
-    url: string;
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-    ({ className, variant, size, asChild = false, url, ...props }, ref) => {
-        const router = useRouter();
+  ({ className, variant, size, asChild, children, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
 
-        const handleClick = () => {
-            router.push(url);
-        };
-
-        const Comp = asChild ? Slot : "button";
-        return (
-            <Comp
-                onClick={handleClick}
-                className={cn(buttonVariants({ variant, size, className }))}
-                ref={ref}
-                {...props}
-            />
-        );
-    },
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      >
+        <Slottable>{children}</Slottable>
+      </Comp>
+    );
+  }
 );
 Button.displayName = "Button";
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -58,8 +58,10 @@ const Home = ({ data }: InferGetStaticPropsType<typeof getStaticProps>) => {
         <p className="mt-2 max-w-xl">{subheading ?? fallbackSubheading}</p>
       </div>
       <section className=".cta">
-        <Button url={ctaButtonUrl ?? fallbackCtaButtonUrl}>
-          {ctaButtonTitle ?? fallbackCtaButtonTitle}
+        <Button asChild>
+          <a href={ctaButtonUrl ?? fallbackCtaButtonUrl} target="_blank">
+            {ctaButtonTitle ?? fallbackCtaButtonTitle}
+          </a>
         </Button>
       </section>
       <div className="flex flex-col gap-y-4">

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -1,6 +1,7 @@
 import { Source_Serif_4 } from "next/font/google";
 import Footer from "../components/Footer";
 import { cn } from "@lib/utils";
+import Header from "@components/Header";
 
 const sourceSerif = Source_Serif_4({
   subsets: ["latin"],
@@ -11,10 +12,11 @@ const RootLayout = ({ children }: Readonly<{ children: React.ReactNode }>) => {
   return (
     <div
       className={cn(
-        `flex min-h-screen flex-col pt-24 container`,
+        `flex min-h-screen flex-col container`,
         sourceSerif.className
       )}
     >
+      <Header />
       {children}
       <Footer />
     </div>

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -10,14 +10,9 @@ const sourceSerif = Source_Serif_4({
 
 const RootLayout = ({ children }: Readonly<{ children: React.ReactNode }>) => {
   return (
-    <div
-      className={cn(
-        `flex min-h-screen flex-col container`,
-        sourceSerif.className
-      )}
-    >
+    <div className={cn(`flex min-h-screen flex-col`, sourceSerif.className)}>
       <Header />
-      {children}
+      <div className="container mt-32">{children}</div>
       <Footer />
     </div>
   );


### PR DESCRIPTION
- [x] drive-by fix: `asChild` on `Button` to support
- [x] Adds `header` to app